### PR TITLE
Split Proxy.handler into two types

### DIFF
--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -2,7 +2,7 @@ type t
 
 val connect :
   S.transport ->
-  ('a, 'v, _, 'v) Proxy.handler ->
+  ('a, 'v) Proxy.Service_handler.t ->
   (t * ('a, 'v) Proxy.t)
 
 val listen : t -> unit Lwt.t

--- a/lib/display.ml
+++ b/lib/display.ml
@@ -11,7 +11,7 @@ let connect transport =
         Log.err (fun f -> f "Received Wayland error: %ld %s on object %ld" code message object_id)
 
       method on_delete_id proxy ~id =
-        Proxy.delete proxy id
+        Proxy.delete_other proxy id
     end
   in
   Lwt.async (fun () -> Connection.listen conn);

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -1,37 +1,60 @@
 type ('a, +'v) t
 (** An [('a, 'v) t] sends messages to an object with interface ['a] and version in ['v]. *)
 
-type ('a, 'v, 'vspawn, 'vbind) handler
-(** An [('a, 'v, 'vspawn, 'vbind) handler] handles incoming messages for an object of type ['a].
-    When created by a normal object (with [spawn]), it handles interface version ['v = 'vspawn],
-    and when created using the registry (using [spawn_bind]) it handles version ['v = 'vbind].
-    Typically, a constructor will let the user pick from a range of versions
-    for ['vspawn], which will then be constrained by the [spawn] call. *)
-
-val interface : _ t -> string
-(** [interface t] is the interface from [t]'s handler metadata. *)
-
-val version : _ t -> int32
-(** [version t] is the actual interface version being used.
-    Normally, this is inherited from the object that created this one, but for registry binds
-    the version comes from the handler. *)
-
-val cast_version : ('a, _, _, _) handler -> ('a, _, _, _) handler
-(** If the version rules turn out to be too restrictive, this can be used to disable them.
-    Using this incorrectly may lead to a protocol error (such as receiving an event for which
-    no handler was registered). *)
+type ('a, 'v) proxy := ('a, 'v) t               (* Alias for use inside this file only *)
 
 (** {2 Functions for use by generated code}
 
     You should not need to use these functions directly.
     Instead, run wayland-scanner-ocaml to generate typed wrappers and use the wrappers instead. *)
 
-val handler : (module Metadata.S) -> version:int32 ->
-  (('a, 'v) t -> ('a, [`R]) Msg.t -> unit) ->
-  ('a, 'v, _, _) handler
-(** [handler metadata ~version dispatch] is a handler for the interface [metadata],
-    which uses [dispatch self msg] to handle incoming messages.
-    If used with [spawn_bind], [version] will be the requested version. *)
+module Handler : sig
+  type ('a, 'v) t
+  (** An [('a, 'v) t] handles incoming messages for an object of type ['a].
+      Typically, a constructor will let the user pick from a range of versions
+      for ['v], which will then be constrained by the [spawn] call. *)
+
+  val v :
+    (module Metadata.S) ->
+    (('a, 'v) proxy -> ('a, [`R]) Msg.t -> unit) ->
+    ('a, 'v) t
+    (** [v metadata dispatch] is a handler for the interface [metadata],
+        which uses [dispatch self msg] to handle incoming messages.
+        Only used by the generated code. *)
+
+  val cast_version : ('a, _) t -> ('a, _) t
+  (** If the version rules turn out to be too restrictive, this can be used to disable them.
+      Using this incorrectly may lead to a protocol error (such as receiving an event for which
+      no handler was registered). *)
+end
+
+module Service_handler : sig
+  type ('a, 'v) t
+  (** An [('a, 'v) t] handles incoming messages for a service object of type ['a].
+      The difference between services and other objects is that a service gets its version at runtime
+      from the bind request, whereas other objects inherit their version from their parent. *)
+
+  val v :
+    version:int32 ->
+    (module Metadata.S) ->
+    (('a, 'v) proxy -> ('a, [`R]) Msg.t -> unit) ->
+    ('a, 'v) t
+    (** [v ~version metadata dispatch] is a handler for the interface [metadata],
+        which uses [dispatch self msg] to handle incoming messages.
+        Only used by the generated code.
+        @param version The version to request in the bind call. *)
+
+  val interface : _ t -> string
+  (** [interface t] is the interface from [t]'s metadata. *)
+
+  val version : _ t -> int32
+  (** [version t] is the version from [t]. *)
+
+  val cast_version : ('a, _) t -> ('a, _) t
+  (** If the version rules turn out to be too restrictive, this can be used to disable them.
+      Using this incorrectly may lead to a protocol error (such as receiving an event for which
+      no handler was registered). *)
+end
 
 val id : _ t -> int32
 (** [id t] is [t]'s object ID. Use this to refer to the object in a message. *)
@@ -43,11 +66,11 @@ val alloc : ('a, _) t -> op:int -> ints:int -> strings:string list -> ('a, [`W])
 val send : ('a, _) t -> ('a, [`W]) Msg.t -> unit
 (** [send t msg] enqueues [msg] on [t]'s connection. *)
 
-val spawn : (_, 'v) t -> ('a, 'v, 'v, _) handler -> ('a, 'v) t
+val spawn : (_, 'v) t -> ('a, 'v) Handler.t -> ('a, 'v) t
 (** Create a new proxy on [t]'s connection with an unused ID.
     The new object has the same version as its parent. *)
 
-val spawn_bind : _ t -> ('a, 'v, _, 'v) handler -> ('a, 'v) t
+val spawn_bind : _ t -> ('a, 'v) Service_handler.t -> ('a, 'v) t
 (** Like [spawn] but the child's version is taken from the handler,
     not inherited from the parent.
     This is used for binding with the global registry. *)
@@ -64,20 +87,12 @@ val unknown_event : int -> string
 val unknown_request : int -> string
 (** A suitable string to display for an unknown request number. *)
 
-val handler_interface : _ handler -> string
-(** [handler_interface h] is the interface from [h]'s metadata.
-    Used for bind-type calls. *)
-
-val handler_version : _ handler -> int32
-(** [handler_version h] is the version from [h].
-    Used for bind-type calls. *)
-
 val pp : _ t Fmt.t
 
 (**/**)
 
-val add_root : Internal.connection -> ('a, 'v, _, 'v) handler -> ('a, 'v) t
+val add_root : Internal.connection -> ('a, 'v) Service_handler.t -> ('a, 'v) t
 (** [add_root conn h] sets [h] as the handler for object 1. *)
 
-val delete : _ t -> int32 -> unit
-(** [delete proxy id] removes [id] from [proxy]'s connection. Internal use only. *)
+val delete_other : _ t -> int32 -> unit
+(** [delete_other proxy id] removes [id] from [proxy]'s connection. Internal use only. *)

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -38,9 +38,9 @@ let get_exn t interface =
   | [] -> Fmt.failwith "Required interface %S not found in registry!" interface
   | e :: _ -> e
 
-let bind t (handler : _ Proxy.handler) =
-  let iface = Proxy.handler_interface handler in
-  let handler_version = Proxy.handler_version handler in
+let bind t handler =
+  let iface = Proxy.Service_handler.interface handler in
+  let handler_version = Proxy.Service_handler.version handler in
   let {name; version} = get_exn t iface in
   if version < handler_version then
     Fmt.failwith "Can't use version %ld of %s; registry only supports <= %ld" handler_version iface version;

--- a/lib/registry.mli
+++ b/lib/registry.mli
@@ -17,7 +17,7 @@ val get : t -> string -> entry list
 val get_exn : t -> string -> entry
 (** [get_exn interface] returns the first entry for [interface], or raises an exception if its not present. *)
 
-val bind : t -> (('a, 'v, _, 'v) Proxy.handler) -> ('a, 'v) Proxy.t
+val bind : t -> (('a, 'v) Proxy.Service_handler.t) -> ('a, 'v) Proxy.t
 (** [bind t handler] gets the entry for [handler]'s interface,
     checks that the version is compatible, and creates a proxy for it.
     Raises an exception if the interface isn't listed, or has the wrong version. *)

--- a/lib/wayland.ml
+++ b/lib/wayland.ml
@@ -11,8 +11,8 @@ module Registry = Registry
     It calls [fn data] when the callback's "done" signal is received.
     Wl_callback seems to be an exception to the usual Wayland versioning rules
     (a wl_callback can be created by multiple objects). *)
-let callback fn : ([ `Wl_callback ], 'v, 'v, [`V1]) Proxy.handler =
-  Proxy.cast_version @@ Wayland_client.Wl_callback.v1 @@ object
+let callback fn : ([ `Wl_callback ], [> `V1]) Proxy.Handler.t =
+  Proxy.Handler.cast_version @@ Wayland_client.Wl_callback.v1 @@ object
     method on_done _ ~callback_data = fn callback_data
   end
 

--- a/scanner/parent.ml
+++ b/scanner/parent.ml
@@ -9,10 +9,10 @@ type t = {
 let index_ops t (parent : Interface.t) (msg : Message.t) =
   msg.args |> List.iter (fun (arg : Arg.t) ->
       match arg.ty with
-      | `New_ID (Some "wl_callback") -> ()  (* Seems to be an exception to the tree rule *)
       | `New_ID (Some interface) ->
         Interface_map.find_opt interface t.parent |> Option.iter (fun (other_parent : Interface.t) ->
-            if other_parent.name <> parent.name then (
+            (* wl_callback seems to be an exception to the tree rule *)
+            if other_parent.name <> parent.name && interface <> "wl_callback" then (
               Fmt.pr "WARNING: Interface %S has two creation parents: %S and %S!@."
                 interface parent.name other_parent.name
             )


### PR DESCRIPTION
Before, it had a complex type allowing it to be used either as a top-level service with `bind`, or as a child. But in fact we can tell
statically what kind of object something is and generate different types for the two cases, simplifying things a lot.