### PR TITLE
Add server-side support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	dune build @check
+	dune build @check @runtest
 
 run: test
 	dune exec -- ./example/test.exe

--- a/README.md
+++ b/README.md
@@ -65,12 +65,147 @@ See the [API documentation][] for more information.
 Each proxy object has phantom types for the interface and the version(s) of that interface.
 e.g. a value of type ``([`Wl_surface], [`V3]) Proxy.t`` is a proxy to a version 3 surface object.
 
-There is one constructor function for each distinct version of an interface.
-e.g. `Wl_surface.v3` could be used to create the proxy above.
+Functions that send messages require a compatible version.
+For example, `Wl_surface.set_buffer_transform` was introduced in version 2,
+and so it can be used with objects supporting version 2, 3 or 4:
+
+```ocaml
+module Wl_surface : sig
+  ...
+  val set_buffer_transform : [< `V2 | `V3 | `V4 ] t ->
+    transform:Wayland_proto.Wl_output.Transform.t -> unit
+  ...
+end
+```
+
+In Wayland, there are two ways of introducing new objects to a conversation:
+
+- In most cases, the schema gives the interface for the created object.
+  In this case, the new object will have the same version as the object
+  from which it was created.
+
+- The registry's `bind` operation does not specify the interface.
+  Instead, the client passes the interface and version as arguments.
+
+When creating an object, you must give handlers for each message that could be received related to that object.
+For example, when using the compositor object to create a surface you must supply a compatible set of handlers:
+
+```ocaml
+module Wl_compositor : sig
+  ...
+  val create_surface : [< `V1 | `V2 | `V3 | `V4 ] as 'v t ->
+    ([ `Wl_surface ], 'v) Proxy.Handler.t ->
+    ([ `Wl_surface ], 'v) Proxy.t
+  ...
+end
+```
+
+This says that `create_surface` can be used with any version `'v` of the compositor,
+but you must supply handlers for version `'v` of the surface object.
+The return value will be a surface proxy with the same version as the compositor.
+
+There is one handler constructor function for each distinct version of an interface.
+For example, to create a handler for version 3 of the surface interface you can use this function:
+
+```ocaml
+module Wl_surface : sig
+  ...
+  val v3 : ([< `V1 | `V2 | `V3 ] as 'v) h3 ->
+           ([ `Wl_surface ], 'v) Proxy.Handler.t
+  ...
+end
+```
+
+The type for `v3` says that if you supply handlers for version 3 of the protocol then
+you get a handler that can be used for object versions 1, 2 or 3.
+When you try to create the surface using a compositor, the creation method will further
+constrain the version to match the compositor's version.
+So the ``[< `V1 | `V2 | `V3 ]`` constraint just prevents you from using this with e.g. a
+v4 compositor.
+
+For example, to use this with a ``[`V2 | `V3] Wl_compositor.t``
+(that is, a compositor that is either v2 or v3), you would use `v3` at type:
+
+```ocaml
+val v3 : [`V2 | `V3] h3 -> ([ `Wl_surface ], [`V2 | `V3]) Proxy.Handler.t
+```
+
+The handlers you pass (`h3`) must handle any incoming v3 message,
+but when sending they can only use messages available in both v2 and v3.
+
+For top-level services (objects that are listed in the registry and for which the
+client specifies the version explicitly), the constructor gives a
+`Proxy.Service_handler.t` instead:
+
+```ocaml
+module Wl_compositor : sig
+  ...
+  val v3 : unit -> ([ `Wl_compositor ], [> `V3 ]) Proxy.Service_handler.t
+  ...
+end
+```
+
+When using `v3`, you don't have to worry about it being a v1 or v2 object,
+as you will get the exact version requested.
+Note: `Wl_compositor` doesn't produce any events, so the handlers are just `()` in this case.
+
+The version types should prevent you from sending messages the other side won't understand,
+or failing to handle a message the other side sends. However, they may be inflexible.
+You can use `Handler.cast_version` to escape from the rules and manage things yourself if necessary.
+
+## Attaching extra data to objects
+
+Sometimes you may pass an object to the other process and then receive it back again later via another message.
+This is mostly needed when implementing a server.
+For example, consider a client that does the following:
+
+1. Create a `Wl_region`.
+2. Add some rectangles to the region.
+3. Pass the region to `Wl_surface.set_input_region`.
+
+When the server gets the region as an argument to `set_input_region`
+it will want to recognise it as a region it created earlier,
+with private state holding the list of rectangles.
+
+You can attach data to a handler by specifying `~user_data` when creating the handler,
+and get it back using `Proxy.user_data`.
+
+Ideally, the application would define the `user_data` type,
+but this would require functorising the whole API and all the bindings over the type, which is inconvenient.
+Instead, `Wayland.S.user_data` is defined as an open variant type and you should extend that with a single entry for your (GADT) type. e.g.
+
+```ocaml
+type 'a my_user_data = 
+  | Region : region_data -> [`Wl_region] my_user_data
+  | Output : output_data -> [`Wl_output] my_user_data
+
+type 'a Wayland.S.user_data += My_user_data of 'a my_user_data
+
+let user_data (proxy : ('a, _) Proxy.t) : 'a my_user_data =
+  match Wayland.Proxy.user_data proxy with
+  | My_user_data x -> x
+  | S.No_data -> Fmt.failwith "No data attached to %a!" Proxy.pp proxy
+  | _ -> Fmt.failwith "Unexpected data attached to %a!" Proxy.pp proxy
+```
+
+Then when you receive a region proxy, do:
+
+```ocaml
+method on_set_input_region _ ~region =
+  let Region r = user_data region in
+  ...
+```
+
+Because the compiler knows that `region` is of type `Wl_region`,
+it knows that the user data will be of type ``[`Wl_region] my_user_data``,
+and so there is only case you have to handle.
+To avoid the exceptions, you just need to ensure that:
+
+1. You don't extend `Wayland.S.user_data` with any other variants.
+2. You don't forget to attach the data when creating the handler.
 
 ## TODO
 
-- Only the client-side is working, although the server-side should be fairly easy.
 - Using `$WAYLAND_SOCKET` to pass an FD doesn't work yet.
 - Needs more testing.
 

--- a/dune-project
+++ b/dune-project
@@ -10,6 +10,7 @@
  (name wayland)
  (synopsis "Pure OCaml Wayland protocol library")
  (depends
+  (alcotest-lwt (and (>= 1.2.3) :with-test))
   (ocaml (>= 4.08.0))
   (xmlm (>= 1.3.0))
   (lwt (>= 5.4.0))

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -1,6 +1,7 @@
 type t
 
 val connect :
+  [`Client | `Server] ->
   S.transport ->
   ('a, 'v) Proxy.Service_handler.t ->
   (t * ('a, 'v) Proxy.t)

--- a/lib/display.ml
+++ b/lib/display.ml
@@ -6,7 +6,7 @@ type t = {
 }
 
 let connect transport =
-  let conn, wl_display = Connection.connect transport @@ Wl_display.v1 @@ object
+  let conn, wl_display = Connection.connect `Client transport @@ Wl_display.v1 @@ object
       method on_error _ ~object_id ~code ~message =
         Log.err (fun f -> f "Received Wayland error: %ld %s on object %ld" code message object_id)
 

--- a/lib/display.mli
+++ b/lib/display.mli
@@ -5,7 +5,7 @@ type t
 val connect : S.transport -> t
 (** [connect transport] runs the Wayland protocol over [transport]
     (typically created with {!Unix_transport.connect}).
-    It spawns a background thread to handling incoming messages. *)
+    It spawns a background thread to handle incoming messages. *)
 
 val sync : t -> unit Lwt.t
 (** Send a sync message to the server and wait for the reply.

--- a/lib/iface_reg.ml
+++ b/lib/iface_reg.ml
@@ -1,0 +1,24 @@
+type 'a ty = ..
+
+type interface = Interface : 'a ty * (module Metadata.S) -> interface
+
+module Unknown = struct
+  let interface = "unknown"
+
+  let events _ = "unknown", []
+  let requests _ = "unknown", []
+
+  type 'a ty += T : string -> [`Unknown] ty
+end
+
+let interfaces = Hashtbl.create 100
+
+let register ty (module M : Metadata.S) =
+  if Hashtbl.mem interfaces M.interface then
+    Fmt.failwith "Wayland interface type %S is already registered!" M.interface;
+  Hashtbl.add interfaces M.interface (Interface (ty, (module M)))
+
+let lookup interface =
+  match Hashtbl.find_opt interfaces interface with
+  | Some x -> x
+  | None -> Interface (Unknown.T interface, (module Unknown))

--- a/lib/iface_reg.mli
+++ b/lib/iface_reg.mli
@@ -1,0 +1,15 @@
+type 'a ty = ..
+
+type interface = Interface : 'a ty * (module Metadata.S) -> interface
+
+val register : 'a ty -> (module Metadata.S) -> unit
+(** Called by the generated code to register each Wayland interface. *)
+
+val lookup : string -> interface
+(** Called by the generated code to convert a string interface to a variant. *)
+
+(** Returned by [lookup] if the interface name isn't registered. *)
+module Unknown : sig
+  include Metadata.S
+  type 'a ty += T : string -> [`Unknown] ty
+end

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -1,4 +1,4 @@
-type ty = [
+type param = [
   | `Uint 
   | `Int 
   | `String 
@@ -9,7 +9,7 @@ type ty = [
   | `FD 
 ]
 
-type arg = string * ty
+type arg = string * param
 (** Argument name and type. *)
 
 type info = int -> string * arg list

--- a/lib/msg.ml
+++ b/lib/msg.ml
@@ -115,7 +115,7 @@ let fds t = t.fds
 
 let cast = Fun.id
 
-let pop_and_show_arg f t : Metadata.ty -> unit = function
+let pop_and_show_arg f t : Metadata.param -> unit = function
   | `Int ->
     Fmt.pf f "%ld" (get_int t)
   | `Uint ->

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -4,12 +4,37 @@ type ('a, 'v) t = 'a Internal.proxy
 
 type ('a, 'v) proxy = ('a, 'v) t
 
+type generic = Proxy : 'a Iface_reg.ty * ('a, [`Unknown]) t -> generic
+
+let missing_dispatch _ = failwith "no handler registered!"
+
+let missing_handler = {
+  metadata = (module Iface_reg.Unknown);
+  user_data = S.No_data;
+  dispatch = missing_dispatch;
+}
+
+(* Register [id] as a new object with a temporary dummy handler.
+   Call [complete_accept] on the result before blocking. *)
+let accept_new t ~version ~handler id =
+  let conn = t.conn in
+  let is_service_allocated_id = (Int32.unsigned_compare id 0xFF000000l >= 0) in
+  if conn.role = `Client then assert is_service_allocated_id
+  else assert (not is_service_allocated_id);
+  if Objects.mem id conn.objects then
+    Fmt.failwith "An object with ID %ld already exists!" id;
+  let t' = { id; version; conn; valid = false; handler } in
+  conn.objects <- Objects.add id (Generic t') conn.objects;
+  t'
+
+let complete_accept t handler =
+  assert (t.handler.dispatch == missing_dispatch);
+  assert (not t.valid);
+  t.handler <- handler;
+  t.valid <- true
+
 module Handler = struct
-  type ('a, 'v) t = {
-    user_data : 'a S.user_data;
-    metadata : (module Metadata.S);
-    handler : ('a, 'v) proxy -> ('a, [`R]) Msg.t -> unit;
-  }
+  type ('a, 'v) t = 'a Internal.handler
 
   let interface t =
     let (module M) = t.metadata in
@@ -17,7 +42,13 @@ module Handler = struct
 
   let cast_version t = (t :> _ t)
 
-  let v ?(user_data=S.No_data) metadata handler = { metadata; handler; user_data }
+  let v ?(user_data=S.No_data) metadata dispatch = { metadata; dispatch; user_data }
+
+  let accept_new proxy id =
+    accept_new proxy id ~version:proxy.version ~handler:missing_handler
+
+  let attach proxy handler =
+    complete_accept proxy handler
 end
 
 module Service_handler = struct
@@ -34,6 +65,22 @@ module Service_handler = struct
 
   let v ~version ?user_data metadata h =
     { version; handler = Handler.v ?user_data metadata h }
+
+  let accept_new proxy id ~interface ~version =
+    let Iface_reg.Interface (ty, (module M : Metadata.S)) = interface in
+    let handler = { metadata = (module M); user_data = S.No_data; dispatch = missing_dispatch } in
+    let proxy' = accept_new proxy ~version ~handler id in
+    Proxy (ty, proxy')
+
+  let attach (proxy : ('a, _) proxy) { handler; version } =
+    let (module M1) = proxy.handler.metadata in
+    let (module M2) = handler.metadata in
+    if M1.interface <> M2.interface then
+      Fmt.invalid_arg "attach: expected interface %S, but got a handler for %S" M1.interface M2.interface;
+    if proxy.version <> version then
+      Fmt.invalid_arg "attach: expected %S to have version %ld, but got a handler for %ld" M1.interface proxy.version version;
+    complete_accept proxy handler;
+    (proxy :> ('a, _) proxy)
 end
 
 let pp = pp_proxy
@@ -46,7 +93,7 @@ let alloc t = Msg.alloc ~obj:t.id
 
 let send (t:_ t) (msg : ('a, [`W]) Msg.t) =
   Log.info (fun f ->
-      let (module M) = t.metadata in
+      let (module M) = t.handler.metadata in
       let outgoing_info =
         match t.conn.role with
         | `Client -> M.requests
@@ -63,26 +110,40 @@ let send (t:_ t) (msg : ('a, [`W]) Msg.t) =
   else
     Fmt.failwith "Attempt to use object %a after calling destructor!" pp t
 
-let spawn_bind t {Service_handler.version; handler = { Handler.metadata; handler; user_data}} =
+let spawn_bind t {Service_handler.version; handler } =
   let conn = t.conn in
   let id = get_unused_id conn in
-  let t' = { id; version; conn = t.conn; valid = true; metadata; user_data } in
-  conn.objects <- Objects.add id (Handler (t', handler)) conn.objects;
+  let t' = { id; version; conn = t.conn; valid = true; handler } in
+  conn.objects <- Objects.add id (Generic t') conn.objects;
   t'
 
 let spawn t handler = spawn_bind t {Service_handler.version = t.version; handler}
 
-let user_data (t:_ t) = t.user_data
+let user_data (t:_ t) = t.handler.user_data
 
 let invalidate t =
   assert t.valid;
   t.valid <- false
 
-let add_root conn { Service_handler.version; handler = { metadata; handler; user_data } } =
+let add_root conn { Service_handler.version; handler } =
   assert (version = 1l);
-  let display_proxy = { metadata; version; id = 1l; conn; valid = true; user_data } in
-  conn.objects <- Objects.add display_proxy.id (Handler (display_proxy, handler)) conn.objects;
+  let display_proxy = { version; id = 1l; conn; valid = true; handler } in
+  conn.objects <- Objects.add display_proxy.id (Generic display_proxy) conn.objects;
   display_proxy
+
+let delete t =
+  let conn = t.conn in
+  assert (conn.role = `Server);
+  match Objects.find_opt t.id conn.objects with
+  | Some (Generic t') when Obj.repr t == Obj.repr t' ->
+    t.valid <- false;
+    conn.objects <- Objects.remove t.id conn.objects;
+    Internal.free_id conn t.id;
+    let Generic display = Objects.find 1l conn.objects in
+    let msg = alloc display ~op:1 ~ints:1 ~strings:[] in
+    Msg.add_int msg t.id;
+    send display msg
+  | _ -> Fmt.failwith "Object %a is not registered!" pp t
 
 let delete_other proxy id =
   let conn = proxy.conn in
@@ -93,3 +154,13 @@ let delete_other proxy id =
 
 let unknown_event = Fmt.strf "<unknown event %d>"
 let unknown_request = Fmt.strf "<unknown request %d>"
+
+let lookup_other_unsafe ~interface (t : ('a, _) t) id : ('b, _) t =
+  match Objects.find_opt id t.conn.objects with
+  | None -> Fmt.failwith "Proxy with ID %ld not found!" id
+  | Some (Generic p) ->
+    let (module M) = p.handler.metadata in
+    if M.interface <> interface then
+      Fmt.failwith "Object %a referenced object %a, which should be of type %S but isn't'" pp t pp p interface;
+    (* If the interfaces are the same then the type must be too, because it's generated directly from the name. *)
+    (Obj.magic p : _ t)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -1,0 +1,26 @@
+open Wayland_server
+
+type t = {
+  conn : Connection.t;
+  wl_display : [`V1] Wl_display.t;
+}
+
+let connect transport registry =
+  let serial = ref 0l in
+  let next_serial () =
+    serial := Int32.succ !serial;
+    !serial
+  in
+  let conn, wl_display = Connection.connect `Server transport @@ Wl_display.v1 @@ object
+      method on_get_registry _ reg = registry reg
+
+      method on_sync _ cb =
+        Proxy.Handler.attach cb @@ Wl_callback.v1 ();
+        Wl_callback.done_ cb ~callback_data:(next_serial ());
+        Proxy.delete cb
+    end
+  in
+  Lwt.async (fun () -> Connection.listen conn);
+  { conn; wl_display }
+
+let wl_display t = t.wl_display

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -1,0 +1,11 @@
+type t
+
+val connect : S.transport -> (([`Wl_registry], [`V1]) Proxy.t -> unit) -> t
+(** [connect transport registry] runs the Wayland protocol over [transport]
+    (typically created with {!Unix_transport.of_socket}).
+    It spawns a background thread to handle incoming messages.
+    [registry] is used to handle requests for the display's registry.
+    You must call {!Proxy.Service_handler.attach registry} before returning
+    or using the proxy. *)
+
+val wl_display : t -> [`V1] Wayland_server.Wl_display.t

--- a/lib/wayland.ml
+++ b/lib/wayland.ml
@@ -16,6 +16,9 @@ let callback fn : ([ `Wl_callback ], [> `V1]) Proxy.Handler.t =
     method on_done _ ~callback_data = fn callback_data
   end
 
+module Server = Server
+(** Code for writing Wayland servers. *)
+
 module Fixed = Fixed
 (** Wayland's 24.8 fixed-point type. *)
 
@@ -46,3 +49,6 @@ module Msg = Msg
 
 module S = S
 (** Type signatures. *)
+
+module Iface_reg = Iface_reg
+(** Registry of known interfaces. Used by the generated code. *)

--- a/tests/dune
+++ b/tests/dune
@@ -1,0 +1,3 @@
+(test
+  (name test)
+  (libraries wayland alcotest-lwt lwt.unix logs.fmt))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,0 +1,127 @@
+open Lwt.Syntax
+open Wayland
+
+type rect = {
+  x : int32;
+  y : int32;
+  width : int32;
+  height : int32;
+}
+
+let pp_rect f {x; y; width; height} = Fmt.pf f "(%ld, %ld)+(%ld, %ld)" x y width height
+
+module S = struct
+  type t = {
+    mutable next_surface : int;
+    mutable log : string list;
+  }
+
+  open Wayland.Wayland_server
+
+  type region_data = rect list ref
+
+  type 'a user_data = 
+    | Region : region_data -> [`Wl_region] user_data
+
+  type 'a Wayland.S.user_data += Server of 'a user_data
+
+  let user_data (proxy : ('a, _) Proxy.t) : 'a user_data =
+    match Wayland.Proxy.user_data proxy with
+    | Server x -> x
+    | S.No_data -> Fmt.failwith "No data attached to %a!" Proxy.pp proxy
+    | _ -> Fmt.failwith "Unexpected data attached to %a!" Proxy.pp proxy
+
+  let comp_name = 1l
+
+  let log t fmt =
+    fmt |> Fmt.kstrf @@ fun msg ->
+    Logs.info (fun f -> f "Server: %s" msg);
+    t.log <- msg :: t.log
+
+  let make_region r =
+    let rects = ref [] in
+    Proxy.Handler.attach r @@ Wl_region.v1 ~user_data:(Server (Region rects)) @@ object
+      method on_add _ ~x ~y ~width ~height =
+        rects := { x; y; width; height } :: !rects
+      method on_destroy _ = ()
+      method on_subtract _ ~x:_ ~y:_ ~width:_ ~height:_ = failwith "Not implemented"
+    end
+
+  let make_surface t m =
+    let sid = t.next_surface in
+    t.next_surface <- t.next_surface + 1;
+    log t "Created surface %d" sid;
+    Proxy.Handler.attach m @@ Wl_surface.v1 @@ object
+      method on_attach _ ~buffer:_ ~x:_ ~y:_ = failwith "Not implemented"
+      method on_commit _ = failwith "Not implemented"
+      method on_damage _ ~x:_ ~y:_ ~width:_ ~height:_ = failwith "Not implemented"
+      method on_destroy _ = failwith "Not implemented"
+      method on_frame _ _callback = failwith "Not implemented"
+      method on_set_input_region _ ~region =
+        let Region r = user_data region in
+        log t "Surface %d input region <- %a" sid (Fmt.(list ~sep:comma) pp_rect) !r
+      method on_set_opaque_region _ ~region:_ = failwith "Not implemented"
+    end
+
+  let make_compositor t proxy =
+    let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ Wl_compositor.v1 @@ object
+        method on_create_region _ region = make_region region
+        method on_create_surface _ surface = make_surface t surface
+      end
+    in
+    ()
+
+  let connect socket =
+    let t = {
+      next_surface = 1;
+      log = [];
+    } in
+    let _ : Server.t =
+      Server.connect socket (fun reg ->
+          Proxy.Handler.attach reg @@ Wl_registry.v1 @@ object
+            method on_bind _ ~name = function
+              | Proxy.Proxy (Wayland_proto.Wl_compositor.T, proxy) ->
+                assert (name = comp_name);
+                make_compositor t proxy
+              | Proxy (_, proxy) -> Fmt.failwith "Invalid service name for %a" Proxy.pp proxy
+          end;
+          Wl_registry.global reg ~name:comp_name ~interface:"wl_compositor" ~version:1l
+        )
+    in t
+
+  let get_log t = List.rev t.log
+end
+
+let test_simple _ () =
+  let socket_c, socket_s = Lwt_unix.(socketpair PF_UNIX SOCK_STREAM 0) in
+  let c = Unix_transport.of_socket socket_c |> Display.connect in
+  let server = Unix_transport.of_socket socket_s |> S.connect in
+  let open Wayland.Wayland_client in
+  let* reg = Registry.of_display c in
+  let comp = Registry.bind reg @@ Wl_compositor.v1 () in
+  let surface = Wl_compositor.create_surface comp @@ Wl_surface.v1 @@ object
+      method on_enter _ ~output:_ = ()
+      method on_leave _ ~output:_ = ()
+    end
+  in
+  let region = Wl_compositor.create_region comp @@ Wl_region.v1 () in
+  Wl_region.add region ~x:10l ~y:20l ~width:30l ~height:40l;
+  Wl_surface.set_input_region surface ~region;
+  let* () = Display.sync c in
+  Alcotest.(check (list string)) "Check log" [
+    "Created surface 1";
+    "Surface 1 input region <- (10, 20)+(30, 40)";
+  ] @@ S.get_log server;
+  Lwt.return ()
+
+let () =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.(set_level (Some Info));
+  Lwt_main.run begin
+    let open Alcotest_lwt in
+    run "wayland" [
+      "protocol", [
+        test_case "simple" `Quick test_simple;
+      ];
+    ]
+  end

--- a/wayland.opam
+++ b/wayland.opam
@@ -8,6 +8,7 @@ doc: "https://talex5.github.io/ocaml-wayland/"
 bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
 depends: [
   "dune" {>= "2.8"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
   "ocaml" {>= "4.08.0"}
   "xmlm" {>= "1.3.0"}
   "lwt" {>= "5.4.0"}


### PR DESCRIPTION
This adds `Wayland.Server` for running the server-side of the protocol (it's mostly the same, except that now we host the wl_display).

It also adds support for receiving object arguments, not just sending them, and adds a simple unit-test with a server and client.