### PR TITLE
Add type to Metadata.S

### DIFF
--- a/lib/iface_reg.ml
+++ b/lib/iface_reg.ml
@@ -1,24 +1,11 @@
-type 'a ty = ..
-
-type interface = Interface : 'a ty * (module Metadata.S) -> interface
-
-module Unknown = struct
-  let interface = "unknown"
-
-  let events _ = "unknown", []
-  let requests _ = "unknown", []
-
-  type 'a ty += T : string -> [`Unknown] ty
-end
-
 let interfaces = Hashtbl.create 100
 
-let register ty (module M : Metadata.S) =
+let register (module M : Metadata.S) =
   if Hashtbl.mem interfaces M.interface then
     Fmt.failwith "Wayland interface type %S is already registered!" M.interface;
-  Hashtbl.add interfaces M.interface (Interface (ty, (module M)))
+  Hashtbl.add interfaces M.interface (module M : Metadata.S)
 
 let lookup interface =
   match Hashtbl.find_opt interfaces interface with
   | Some x -> x
-  | None -> Interface (Unknown.T interface, (module Unknown))
+  | None -> Fmt.failwith "Unknown Wayland interface %S" interface

--- a/lib/iface_reg.mli
+++ b/lib/iface_reg.mli
@@ -1,15 +1,5 @@
-type 'a ty = ..
-
-type interface = Interface : 'a ty * (module Metadata.S) -> interface
-
-val register : 'a ty -> (module Metadata.S) -> unit
+val register : (module Metadata.S) -> unit
 (** Called by the generated code to register each Wayland interface. *)
 
-val lookup : string -> interface
+val lookup : string -> (module Metadata.S)
 (** Called by the generated code to convert a string interface to a variant. *)
-
-(** Returned by [lookup] if the interface name isn't registered. *)
-module Unknown : sig
-  include Metadata.S
-  type 'a ty += T : string -> [`Unknown] ty
-end

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -20,7 +20,7 @@ type connection = {
 and generic_proxy = Generic : 'a proxy -> generic_proxy
 and 'a handler = {
   user_data : 'a S.user_data;
-  metadata : (module Metadata.S);
+  metadata : (module Metadata.S with type t = 'a);
   dispatch : 'a proxy -> ('a, [`R]) Msg.t -> unit;
 }
 
@@ -59,6 +59,6 @@ let enqueue t buf =
   Queue.add buf t.outbox;
   if start_transmit_thread then Lwt.async (fun () -> transmit t)
 
-let pp_proxy f (x: _ proxy) =
-  let (module M) = x.handler.metadata in
+let pp_proxy f (type a) (x: a proxy) =
+  let (module M : Metadata.S with type t = a) = x.handler.metadata in
   Fmt.pf f "%s@%ld" M.interface x.id

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -1,3 +1,5 @@
+type 'a ty = ..
+
 type param = [
   | `Uint 
   | `Int 
@@ -16,6 +18,9 @@ type info = int -> string * arg list
 (** A function that takes an operation number and returns the operation name and argument metadata. *)
 
 module type S = sig
+  type t
+  type _ ty += T : t ty
+
   val interface : string
   val requests : info
   val events : info

--- a/protocols/dune
+++ b/protocols/dune
@@ -6,4 +6,4 @@
 (rule
  (targets xdg_shell_client.ml xdg_shell_server.ml xdg_shell_proto.ml)
  (deps   xdg-shell.xml)
- (action (run %{bin:wayland-scanner-ocaml} %{deps})))
+ (action (run %{bin:wayland-scanner-ocaml} --open Wayland.Wayland_proto %{deps})))

--- a/scanner/generate.mli
+++ b/scanner/generate.mli
@@ -1,1 +1,1 @@
-val output : internal:bool -> Schema.Protocol.t -> unit
+val output : opens:string list -> internal:bool -> Schema.Protocol.t -> unit

--- a/scanner/scanner.ml
+++ b/scanner/scanner.ml
@@ -1,8 +1,8 @@
-let scan internal path =
+let scan opens internal path =
   let ch = open_in_bin path in
   match Xml.parse ~name:path ch Schema.Protocol.parse with
   | exception Failure msg -> Fmt.epr "%s@." msg; exit 1
-  | protocol -> Generate.output ~internal protocol
+  | protocol -> Generate.output ~opens ~internal protocol
 
 open Cmdliner
 
@@ -17,7 +17,14 @@ let internal =
     ~doc:"For internal use only"
     ["internal"]
 
-let scan = Term.(const scan $ internal $ spec_file)
+let opens =
+  Arg.value @@
+  Arg.(opt (list string)) [] @@
+  Arg.info
+    ~doc:"Extra modules to open"
+    ["open"]
+
+let scan = Term.(const scan $ opens $ internal $ spec_file)
 
 let term_exit (x : unit Term.result) = Term.exit x
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -79,11 +79,13 @@ module S = struct
     let _ : Server.t =
       Server.connect socket (fun reg ->
           Proxy.Handler.attach reg @@ Wl_registry.v1 @@ object
-            method on_bind _ ~name = function
-              | Proxy.Proxy (Wayland_proto.Wl_compositor.T, proxy) ->
+            method on_bind : type a. _ -> name:int32 -> (a, [`Unknown]) Proxy.t -> unit =
+              fun _ ~name proxy ->
+              match Proxy.ty proxy with
+              | Wayland_proto.Wl_compositor.T ->
                 assert (name = comp_name);
                 make_compositor t proxy
-              | Proxy (_, proxy) -> Fmt.failwith "Invalid service name for %a" Proxy.pp proxy
+              | _ -> Fmt.failwith "Invalid service name for %a" Proxy.pp proxy
           end;
           Wl_registry.global reg ~name:comp_name ~interface:"wl_compositor" ~version:1l
         )


### PR DESCRIPTION
This simplifies the API a little, and removes the only `Obj.magic` call.