### PR TITLE
Allow servers control over deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,29 @@ To avoid the exceptions, you just need to ensure that:
 1. You don't extend `Wayland.S.user_data` with any other variants.
 2. You don't forget to attach the data when creating the handler.
 
+## Deleting objects
+
+Some message types are marked as "destructors".
+Usually the client sends a destructor request and the server acknowledges it.
+In some cases (e.g. callbacks, which have no requests), the server calls the destructor.
+
+After a client either sends or receives a destructor message,
+the object is marked as invalid and cannot be used for sending further messages.
+However, it can still receive them.
+When the client receives the delete acknowledgement,
+the object is removed from the table and its ID can be reused.
+Unlike other handlers, client destructor handlers do not take a proxy argument since
+the proxy is unusable by this point.
+
+On the server side, the handler will normally respond to a destructor call
+by calling `Proxy.delete` immediately.
+However, when relaying to an upstream service it may be useful to delay this
+until the upstream service has confirmed the deletion too.
+
 ## TODO
 
 - Using `$WAYLAND_SOCKET` to pass an FD doesn't work yet.
+- Version typing for server-side top-level objects needs work.
 - Needs more testing.
 
 [The Wayland Protocol]: https://wayland-book.com/

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -14,6 +14,7 @@ type 'role connection = {
   id : int32;
   conn : 'role connection;
   version : int32;
+  on_delete : (unit -> unit) Queue.t;
   mutable handler : ('a, 'role) handler;
   mutable valid : bool;
 }

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -23,6 +23,14 @@ val ty : ('a, _, 'role) t -> 'a Metadata.ty
 
 val interface : _ t -> string
 
+val delete : (_, _, [`Server]) t -> unit
+(** [delete t] sends a delete event from object 1 and removes [t] from the
+    object table. This is only used in server code. *)
+
+val on_delete : (_, _, _) t -> (unit -> unit) -> unit
+(** [on_delete t f] calls [f] when [t] is deleted, either by [delete] being called (on the server)
+    or when the client receives confirmation of the deletion from the server. *)
+
 (** {2 Functions for use by generated code}
 
     You should not need to use these functions directly.
@@ -142,11 +150,6 @@ val unknown_event : int -> string
 
 val unknown_request : int -> string
 (** A suitable string to display for an unknown request number. *)
-
-val delete : (_, _, [`Server]) t -> unit
-(** [delete t] sends a delete event from object 1 and removes [t] from the
-    object table. This is only used in server code, and is called automatically
-    by the generated code when receiving a destructor request. *)
 
 val pp : _ t Fmt.t
 

--- a/scanner/generate.ml
+++ b/scanner/generate.ml
@@ -395,7 +395,7 @@ let make_wrappers ~opens ~internal role (protocol : Protocol.t) f =
               let args = Fmt.strf "@[%a@]" (pp_sig ~role ~next_tvar protocol iface) msg.args in
               line "method virtual on_%s : @[%a@]%s %s"
                 msg.name pp_tvars !next_tvar
-                (if msg.ty = `Normal then "'v t ->" else "")
+                (if msg.ty = `Normal || role = `Server then "'v t ->" else "")
                 args;
               comment f msg.description;
               Fmt.cut f ()
@@ -444,10 +444,11 @@ let make_wrappers ~opens ~internal role (protocol : Protocol.t) f =
                         (if arg.allow_null then "_opt" else "");
                   end;
                 );
-              if msg.ty = `Destructor && role = `Server then line "Proxy.delete _proxy;";
+              if msg.ty = `Destructor && role = `Client then
+                line "Proxy.invalidate _proxy;";
               line "_handlers#on_%s %s@[%a@]@]"
                 msg.name
-                (if msg.ty = `Normal then "_proxy " else "")
+                (if msg.ty = `Normal || role = `Server then "_proxy " else "")
                 (pp_args ~role ~with_types:false) msg.args;
             );
           if version > 1 then

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -43,7 +43,7 @@ module S = struct
     Proxy.Handler.attach r @@ Wl_region.v1 ~user_data:(Server (Region rects)) @@ object
       method on_add _ ~x ~y ~width ~height =
         rects := { x; y; width; height } :: !rects
-      method on_destroy = ()
+      method on_destroy t = Proxy.delete t
       method on_subtract _ ~x:_ ~y:_ ~width:_ ~height:_ = failwith "Not implemented"
     end
 


### PR DESCRIPTION
Before, when a client called a destructor the generated handlers automatically removed it and replied with a confirmation. However, for proxy servers it's convenient to delay the confirmation until the upstream proxy is also deleted. This way, we can continue proxing events from the upstream object and the client doesn't see anything unusual.