### PR TITLE
Improve version handling

### DIFF
--- a/example/test.ml
+++ b/example/test.ml
@@ -66,14 +66,14 @@ let () =
       );
     (* Get the registry and find the objects we need. *)
     let* reg = Registry.of_display display in
-    let compositor = Registry.bind reg (new Wl_compositor.handlers ~version:4l) in
+    let compositor = Registry.bind reg (new Wl_compositor.v4) in
     let shm = Registry.bind reg @@ object
-        inherit [_] Wl_shm.handlers ~version:1l
+        inherit Wl_shm.v1
         method on_format _ ~format:_ = ()
       end
     in
     let xdg_wm_base = Registry.bind reg @@ object
-        inherit [_] Xdg_wm_base.handlers ~version:1l
+        inherit Xdg_wm_base.v1
         method on_ping = Xdg_wm_base.pong
       end
     in
@@ -84,7 +84,7 @@ let () =
       end
     in
     let seat = Registry.bind reg @@ object
-        inherit [_] Wl_seat.handlers ~version:1l
+        inherit Wl_seat.v1
         method on_capabilities _ ~capabilities:_ = ()
         method on_name _ ~name:_ = ()
       end

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -16,7 +16,7 @@ let rec process_recv_buffer t recv_buffer =
         let msg = Msg.cast msg in
         t.trace.inbound proxy msg;
         if proxy.can_recv then
-          proxy.handler.dispatch proxy msg
+          proxy.handler#dispatch proxy msg
         else
           Fmt.failwith "Received message for %a, which was shut down!" pp_proxy proxy
     end;
@@ -74,7 +74,7 @@ let connect ~trace role transport handler =
     set_closed;
     trace = Proxy.trace trace;
   } in
-  let display_proxy = Proxy.add_root t handler in
+  let display_proxy = Proxy.add_root t (handler :> _ Proxy.Service_handler.t) in
   Lwt.async (fun () -> listen t);
   (t, display_proxy)
 

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -74,7 +74,7 @@ let connect ~trace role transport handler =
     set_closed;
     trace = Proxy.trace trace;
   } in
-  let display_proxy = Proxy.add_root t (handler :> _ Proxy.Service_handler.t) in
+  let display_proxy = Proxy.add_root t (handler :> _ Proxy.Handler.t) in
   Lwt.async (fun () -> listen t);
   (t, display_proxy)
 

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -4,7 +4,7 @@ val connect :
   trace:(module Proxy.TRACE with type role = 'role) ->
   ([< `Client | `Server] as 'role) ->
   #S.transport ->
-  ('a, 'v, 'role) Proxy.Service_handler.t ->
+  ('a, 'v, 'role) #Proxy.Service_handler.t ->
   ('role t * ('a, 'v, 'role) Proxy.t)
 
 val closed : [< `Client | `Server ] t -> (unit, exn) Lwt_result.t

--- a/lib/display.ml
+++ b/lib/display.ml
@@ -33,7 +33,7 @@ end
 
 let connect ?(trace=(module Trace : TRACE)) transport =
   let conn, wl_display = Connection.connect ~trace `Client transport @@ object
-      inherit [_] Wl_display.handlers ~version:1l
+      inherit Wl_display.v1
 
       method on_error _ ~object_id ~code ~message =
         Log.err (fun f -> f "Received Wayland error: %ld %S on object %ld" code message object_id)

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -23,11 +23,11 @@ type 'role connection = {
   mutable can_recv : bool;  (* False once the peer has called a destructor. *)
 }
 and 'role generic_proxy = Generic : ('a, 'role) proxy -> 'role generic_proxy
-and ('a, 'role) handler = {
+and ('a, 'role) handler = <
   user_data : ('a, 'role) S.user_data;
   metadata : (module Metadata.S with type t = 'a);
   dispatch : ('a, 'role) proxy -> ('a, [`R]) Msg.t -> unit;
-}
+>
 and 'role tracer = {
   outbound : 'a. ('a, 'role) proxy -> ('a, [`W]) Msg.t -> unit;
   inbound : 'a. ('a, 'role) proxy -> ('a, [`R]) Msg.t -> unit;
@@ -97,5 +97,5 @@ let enqueue t msg =
   )
 
 let pp_proxy f (type a) (x: (a, _) proxy) =
-  let (module M : Metadata.S with type t = a) = x.handler.metadata in
+  let (module M : Metadata.S with type t = a) = x.handler#metadata in
   Fmt.pf f "%s@%lu" M.interface x.id

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -22,8 +22,8 @@ let remove db ~name =
 
 let of_display d =
   let db = Hashtbl.create 20 in
-  let registry = Wl_display.get_registry (Display.wl_display d) @@
-    Wl_registry.v1 @@ object
+  let registry = Wl_display.get_registry (Display.wl_display d) @@ object
+      inherit [_] Wl_registry.handlers
       method on_global _ = add db
       method on_global_remove _ = remove db
     end

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -40,10 +40,10 @@ let get_exn t interface =
 
 let bind t handler =
   let iface = Proxy.Service_handler.interface handler in
-  let handler_version = Proxy.Service_handler.version handler in
-  let {name; version} = get_exn t iface in
-  if version < handler_version then
-    Fmt.failwith "Can't use version %ld of %s; registry only supports <= %ld" handler_version iface version;
-  Wl_registry.bind t.registry ~name handler
+  let min_version = handler#min_version in
+  let {name; version = service_max_version} = get_exn t iface in
+  if service_max_version < min_version then
+    Fmt.failwith "Can't use version %ld of %s; registry only supports <= %ld" min_version iface service_max_version;
+  Wl_registry.bind t.registry ~name (handler, min handler#max_version service_max_version)
 
 let wl_registry t = t.registry

--- a/lib/registry.mli
+++ b/lib/registry.mli
@@ -17,7 +17,7 @@ val get : t -> string -> entry list
 val get_exn : t -> string -> entry
 (** [get_exn interface] returns the first entry for [interface], or raises an exception if its not present. *)
 
-val bind : t -> (('a, 'v, [`Client]) Proxy.Service_handler.t) -> ('a, 'v, [`Client]) Proxy.t
+val bind : t -> (('a, 'v, [`Client]) #Proxy.Service_handler.t) -> ('a, 'v, [`Client]) Proxy.t
 (** [bind t handler] gets the entry for [handler]'s interface,
     checks that the version is compatible, and creates a proxy for it.
     Raises an exception if the interface isn't listed, or has the wrong version. *)

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -3,7 +3,7 @@ type t
 module type TRACE = Proxy.TRACE with type role = [`Server]
 
 val connect : ?trace:(module TRACE) ->
-  S.transport -> ([`Wl_display], [`V1], [`Server]) Proxy.Service_handler.t -> t
+  S.transport -> ([`Wl_display], [`V1], [`Server]) #Proxy.Service_handler.t -> t
 (** [connect transport handler] runs the Wayland protocol over [transport]
     (typically created with {!Unix_transport.of_socket}).
     It spawns a background thread to handle incoming messages. *)

--- a/lib/wayland.ml
+++ b/lib/wayland.ml
@@ -11,10 +11,10 @@ module Registry = Registry
     It calls [fn data] when the callback's "done" signal is received.
     Wl_callback seems to be an exception to the usual Wayland versioning rules
     (a wl_callback can be created by multiple objects). *)
-let callback fn : ([ `Wl_callback ], [> ], [`Client]) Proxy.Handler.t =
-  Proxy.Handler.cast_version @@ Wayland_client.Wl_callback.v1 @@ object
-    method on_done ~callback_data = fn callback_data
-  end
+let callback fn = object
+  inherit [_] Wayland_client.Wl_callback.handlers
+  method on_done ~callback_data = fn callback_data
+end
 
 module Server = Server
 (** Code for writing Wayland servers. *)

--- a/scanner/parent.ml
+++ b/scanner/parent.ml
@@ -3,29 +3,32 @@ open Schema
 module Interface_map = Map.Make(String)
 
 type t = {
-  mutable parent : Interface.t Interface_map.t;
+  mutable parent : (Interface.t * [`Request | `Event]) Interface_map.t;
+  (** Says which interface creates this object, and whether its done by a request or an event. *)
 }
 
-let index_ops t (parent : Interface.t) (msg : Message.t) =
+let index_ops ~msg_type t (parent : Interface.t) (msg : Message.t) =
   msg.args |> List.iter (fun (arg : Arg.t) ->
       match arg.ty with
       | `New_ID (Some interface) ->
-        Interface_map.find_opt interface t.parent |> Option.iter (fun (other_parent : Interface.t) ->
+        Interface_map.find_opt interface t.parent |> Option.iter (fun ((other_parent : Interface.t), other_msg_type) ->
             (* wl_callback seems to be an exception to the tree rule *)
             if other_parent.name <> parent.name && interface <> "wl_callback" then (
               Fmt.pr "WARNING: Interface %S has two creation parents: %S and %S!@."
                 interface parent.name other_parent.name
-            )
+            );
+            if other_msg_type <> msg_type then
+              Fmt.pr "WARNING: Interface %S is created by both clients and servers!" interface;
           );
-        t.parent <- Interface_map.add interface parent t.parent
+        t.parent <- Interface_map.add interface (parent, msg_type) t.parent
       | _ -> ()
     )
 
 let index (p : Protocol.t) =
   let t = { parent = Interface_map.empty } in
   p.interfaces |> List.iter (fun (iface : Interface.t) ->
-      List.iter (index_ops t iface) iface.events;
-      List.iter (index_ops t iface) iface.requests
+      List.iter (index_ops t iface ~msg_type:`Event) iface.events;
+      List.iter (index_ops t iface ~msg_type:`Request) iface.requests
     );
   t
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -74,13 +74,11 @@ module S = struct
     end
 
   let make_compositor t proxy =
-    let _ : _ Proxy.t = Proxy.Service_handler.attach proxy @@ object
-        inherit [_] Wl_compositor.handlers ~version:1l
-        method on_create_region _ region = make_region region
-        method on_create_surface _ surface = make_surface t surface
-      end
-    in
-    ()
+    Proxy.Service_handler.attach proxy @@ object
+      inherit [_] Wl_compositor.handlers
+      method on_create_region _ region = make_region region
+      method on_create_surface _ surface = make_surface t surface
+    end
 
   let connect socket =
     let t = {
@@ -95,7 +93,7 @@ module S = struct
     in
     let s : Server.t =
       Server.connect socket @@ object
-        inherit [_] Wl_display.handlers ~version:1l
+        inherit [_] Wl_display.handlers
         method on_sync _ cb =
           Proxy.Handler.attach cb @@ new Wl_callback.handlers;
           Wl_callback.done_ cb ~callback_data:(next_serial ());
@@ -136,7 +134,7 @@ let test_simple _ () =
   let server = Unix_transport.of_socket socket_s |> S.connect in
   let open Wayland.Wayland_client in
   let* reg = Registry.of_display c in
-  let comp = Registry.bind reg @@ new Wl_compositor.handlers ~version:1l in
+  let comp = Registry.bind reg @@ new Wl_compositor.v1 in
   let surface = Wl_compositor.create_surface comp @@ object
       inherit [_] Wl_surface.handlers
       method on_enter _ ~output:_ = ()


### PR DESCRIPTION
New rules for version handling:

- Clients can specify a minimum version they require, but must support all higher versions (in their copy of the schema).
- Servers must support all versions in their copy of the schema.

This allows a reasonable amount of flexibility without requiring us to generate a huge number of version combinations.

It could be extended so that each handler takes a proxy whose versions are the intersection of the minimum version and the versions supporting that method. To help with this, handlers are now implemented by extending a base class, which will allow forall types in methods. It also provides better error messages.