### PR TITLE
Improve proxy version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Pure OCaml Wayland protocol library
 
-Status: **prototyping**
-
 * [API documentation][]
 
 Wayland is a communications protocol intended for use between processes on a single computer.
@@ -105,22 +103,22 @@ This says that `create_surface` can be used with any version `'v` of the composi
 but you must supply handlers for version `'v` of the surface object.
 The return value will be a surface proxy with the same version as the compositor.
 
-When binding a top-level service, there is one handler constructor function for each distinct version.
-For example, to create a handler for version 3 (or later) of the compositor interface
-you would have your handlers inherit from `Wl_compositor.v3`
+There is one handler class for each distinct version.
+For example, to create a handler for version 4 (or later) of the compositor interface
+you would have your handlers inherit from `Wl_compositor.v4`
 (or just use it directly, since in this case there are no events to be handled). e.g.
 
 ```ocaml
-let compositor = Registry.bind reg @@ new Wl_compositor.v3 in
-(* [compositor] has type [([ `Wl_compositor ], [ `V3 | `V4 ], [ `Client ]) Proxy.t]. *)
+let compositor = Registry.bind reg @@ new Wl_compositor.v4 in
+(* [compositor] has type [[`V4] Wl_compositor.t]. *)
 ```
 
-This means that you can send any compositor request that was available in version 3
+This means that you can send any compositor request that was available in version 4
 (but the `bind` will fail if the server doesn't support this version).
-When you create new objects using the compositor, it will know that they also will be version 3 or later.
+When you create new objects using the compositor, it will know that they also will be version 4.
 
 To avoid an explosion of version combinations,
-the generated handler types require you to handle incoming messages of all versions in your copy of the schema.
+the generated handler types require you to handle incoming messages of all later versions in your copy of the schema.
 For example, you can't ask for exactly version 3 of the compositor
 and then not bother implementing handlers for v4 events.
 

--- a/example/test.ml
+++ b/example/test.ml
@@ -22,7 +22,7 @@ let draw_frame t =
   let stride = t.width * 4 in
   let size = t.height * stride in
   let pool, data = Shm.with_memory_fd ~size (fun fd ->
-      let pool = Wl_shm.create_pool t.shm (new Wl_shm_pool.handlers) ~fd ~size:(Int32.of_int size) in
+      let pool = Wl_shm.create_pool t.shm (new Wl_shm_pool.v1) ~fd ~size:(Int32.of_int size) in
       let ba = Unix.map_file fd Bigarray.Int32 Bigarray.c_layout true [| t.height; t.width |] in
       pool, Bigarray.array2_of_genarray ba
     ) in
@@ -34,7 +34,7 @@ let draw_frame t =
       ~stride:(Int32.of_int stride)
       ~format:Wl_shm.Format.Xrgb8888
     @@ object
-      inherit [_] Wl_buffer.handlers
+      inherit [_] Wl_buffer.v1
       method on_release = Wl_buffer.destroy
     end
   in
@@ -68,23 +68,23 @@ let () =
     let* reg = Registry.of_display display in
     let compositor = Registry.bind reg (new Wl_compositor.v4) in
     let shm = Registry.bind reg @@ object
-        inherit Wl_shm.v1
+        inherit [_] Wl_shm.v1
         method on_format _ ~format:_ = ()
       end
     in
     let xdg_wm_base = Registry.bind reg @@ object
-        inherit Xdg_wm_base.v1
+        inherit [_] Xdg_wm_base.v1
         method on_ping = Xdg_wm_base.pong
       end
     in
     let surface = Wl_compositor.create_surface compositor @@ object
-        inherit [_] Wl_surface.handlers
+        inherit [_] Wl_surface.v1
         method on_enter _ ~output:_ = ()
         method on_leave _ ~output:_ = ()
       end
     in
     let seat = Registry.bind reg @@ object
-        inherit Wl_seat.v1
+        inherit [_] Wl_seat.v1
         method on_capabilities _ ~capabilities:_ = ()
         method on_name _ ~name:_ = ()
       end
@@ -92,7 +92,7 @@ let () =
     let t = { shm; surface; scroll = 0; vy = 1; width = 0; height = 0; fg = 0xFFEEEEEEl } in
     let closed, set_closed = Lwt.wait () in
     let _keyboard = Wl_seat.get_keyboard seat @@ object
-        inherit [_] Wl_keyboard.handlers
+        inherit [_] Wl_keyboard.v1
         method on_keymap    _ ~format:_ ~fd ~size:_ = Unix.close fd
         method on_enter     _ ~serial:_ ~surface:_ ~keys:_ = ()
         method on_leave     _ ~serial:_ ~surface:_ = ()
@@ -105,7 +105,7 @@ let () =
       end
     in
     let _pointer = Wl_seat.get_pointer seat @@ object
-        inherit [_] Wl_pointer.handlers
+        inherit [_] Wl_pointer.v1
         method on_axis _ ~time:_ ~axis:_ ~value:_ = ()
         method on_button _ ~serial:_ ~time:_ ~button:_ ~state =
           match state with
@@ -122,7 +122,7 @@ let () =
     in
     let configured, set_configured = Lwt.wait () in
     let xdg_surface = Xdg_wm_base.get_xdg_surface xdg_wm_base ~surface @@ object
-        inherit [_] Xdg_surface.handlers
+        inherit [_] Xdg_surface.v1
         method on_configure proxy ~serial =
           Xdg_surface.ack_configure proxy ~serial;
           if Lwt.is_sleeping configured then
@@ -130,7 +130,7 @@ let () =
       end
     in
     let toplevel = Xdg_surface.get_toplevel xdg_surface @@ object
-        inherit [_] Xdg_toplevel.handlers
+        inherit [_] Xdg_toplevel.v1
         method on_configure _ ~width ~height ~states:_ =
           t.width <- if width = 0l then 640 else Int32.to_int width;
           t.height <- if height = 0l then 480 else Int32.to_int height

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -43,7 +43,7 @@ end
 let connect ?(trace=(module Trace : TRACE)) transport =
   Lazy.force init_logging;
   let conn, wl_display = Connection.connect ~trace `Client transport @@ object
-      inherit Wl_display.v1
+      inherit [_] Wl_display.v1
 
       method on_error _ ~object_id ~code ~message =
         Log.err (fun f -> f "Received Wayland error: %ld %S on object %ld" code message object_id)
@@ -57,7 +57,7 @@ let connect ?(trace=(module Trace : TRACE)) transport =
 let sync t =
   let result, set_result = Lwt.wait () in
   let _ : _ Wl_callback.t = Wl_display.sync t.wl_display @@ object
-      inherit [_] Wl_callback.handlers
+      inherit [_] Wl_callback.v1
       method on_done ~callback_data:_ = Lwt.wakeup set_result ()
     end
   in

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -101,12 +101,12 @@ module Service_handler : sig
       since otherwise processing a message addressed to the new object will fail.
       This is called from the generated code; the user code then calls the result. *)
 
-  val attach_proxy : ('a, [`Unknown], 'role) proxy -> ('a, 'v, 'role) #t -> ('a, 'v, 'role) proxy
+  val attach_proxy : ('a, [`Unknown], 'role) proxy -> ('a, ([> `V1] as 'v), 'role) #t -> ('a, 'v, 'role) proxy
   (** [attach_proxy p t] sets [t] as the handler for [p],
       which must be a partly initialised proxy returned by [accept_new].
       It returns the proxy with its version cast to the handler's version. *)
 
-  val attach : ('a, [`Unknown], 'role) proxy -> ('a, 'v, 'role) #t -> unit
+  val attach : ('a, [`Unknown], 'role) proxy -> ('a, [> `V1], 'role) #t -> unit
   (** Like [attach_proxy], but ignores the resulting proxy.
       Useful if the object only needs to respond to messages from the peer. *)
 end

--- a/lib/registry.ml
+++ b/lib/registry.ml
@@ -11,6 +11,11 @@ type t = {
   registry : [`V1] Wl_registry.t;
 }
 
+type ('a, 'v) handler = <
+  ('a, 'v, [`Client]) Proxy.Service_handler.t;
+  bind_version : 'v;
+>
+
 let add db ~name ~interface ~version =
   Hashtbl.add db interface { name; version }
 
@@ -23,7 +28,7 @@ let remove db ~name =
 let of_display d =
   let db = Hashtbl.create 20 in
   let registry = Wl_display.get_registry (Client.wl_display d) @@ object
-      inherit [_] Wl_registry.handlers
+      inherit [_] Wl_registry.v1
       method on_global _ = add db
       method on_global_remove _ = remove db
     end

--- a/lib/registry.mli
+++ b/lib/registry.mli
@@ -7,6 +7,11 @@ type entry = {
 
 type t
 
+type ('a, 'v) handler = <
+  ('a, 'v, [`Client]) Proxy.Service_handler.t;
+  bind_version : 'v;
+>
+
 val of_display : Client.t -> t Lwt.t
 (** [of_display d] creates a new registry from a display.
     It performs a sync before returning the result, so that the registry is fully-populated. *)
@@ -17,7 +22,7 @@ val get : t -> string -> entry list
 val get_exn : t -> string -> entry
 (** [get_exn interface] returns the first entry for [interface], or raises an exception if its not present. *)
 
-val bind : t -> (('a, 'v, [`Client]) #Proxy.Service_handler.t) -> ('a, 'v, [`Client]) Proxy.t
+val bind : t -> <('a, 'v) handler; ..> -> ('a, 'v, [`Client]) Proxy.t
 (** [bind t handler] gets the entry for [handler]'s interface,
     checks that the version is compatible, and creates a proxy for it.
     Raises an exception if the interface isn't listed, or has the wrong version. *)

--- a/lib/wayland.ml
+++ b/lib/wayland.ml
@@ -12,7 +12,7 @@ module Registry = Registry
     Wl_callback seems to be an exception to the usual Wayland versioning rules
     (a wl_callback can be created by multiple objects). *)
 let callback fn = object
-  inherit [_] Wayland_client.Wl_callback.handlers
+  inherit [_] Wayland_client.Wl_callback.v1
   method on_done ~callback_data = fn callback_data
 end
 


### PR DESCRIPTION
Previously, only the creator of a top-level service specified the minimum version. Now, we do that for all handlers. This means that you can be sure you have at least the minimum version you requested in each message handler.

For messages that were introduced in version N, we also now provide a proxy of at least version N. For example, when handling the `Wl_data_offer.on_set_actions` message (introduced in version 3), you can respond by sending `Wl_data_offer.action` (also introduced in version 3). You can do this even in a handler that supports version 1 or
later.