### PR TITLE
Handle SIGPIPE properly

### DIFF
--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -85,7 +85,7 @@ let enqueue t msg =
         (fun () -> transmit t)
         (fun ex ->
            if Lwt.is_sleeping t.closed then (
-             Lwt.wakeup_exn t.set_closed ex;
+             Lwt.wakeup t.set_closed (Error ex);
            ) else
              Log.debug (fun f -> f "Transmit failed (but connection already closed): %a" Fmt.exn ex);
            Queue.iter cancel_msg t.outbox

--- a/lib/unix_transport.ml
+++ b/lib/unix_transport.ml
@@ -1,5 +1,8 @@
 open Lwt.Syntax
 
+(* SIGPIPE makes no sense in a modern application. *)
+let () = Sys.(set_signal sigpipe Signal_ignore)
+
 let xdg_runtime_dir () =
   match Sys.getenv_opt "XDG_RUNTIME_DIR" with
   | Some x -> x


### PR DESCRIPTION
- Ensure SIGPIPE doesn't raise a signal.
- Use `wakeup` with `Error` instead of `wakeup_exn` to report write failures.