### PR TITLE
Add Proxy.can_send

### DIFF
--- a/lib/msg.ml
+++ b/lib/msg.ml
@@ -119,7 +119,7 @@ let parse ~fds cs =
         NE.get_uint16 cs 6
       )
     in
-    if Cstruct.len cs >= len then (
+    if Cstruct.length cs >= len then (
       Some { buffer = Cstruct.sub cs 0 len; next = 8; fds }
     ) else (
       None

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -108,7 +108,9 @@ module Service_handler = struct
     proxy
 end
 
-let id t = t.id
+let id t =
+  if t.can_send then t.id
+  else Fmt.invalid_arg "Attempt to use %a after destroying it" pp t
 
 let id_opt = function
   | None -> 0l

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -52,6 +52,8 @@ let version t = t.version
 
 let metadata t = t.handler#metadata
 
+let can_send t = t.can_send
+
 let ty (type a) t =
   let (module M : Metadata.S with type t = a) = metadata t in
   M.T

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -35,6 +35,10 @@ val on_delete : (_, _, _) t -> (unit -> unit) -> unit
 (** [on_delete t f] calls [f] when [t] is deleted, either by [delete] being called (on the server)
     or when the client receives confirmation of the deletion from the server. *)
 
+val can_send : (_, _, _) t -> bool
+(** [can_send t] is [true] if the proxy can still be used in out-going messages.
+    It becomes false after calling {!delete} or {!shutdown_send}. *)
+
 (** {2 Functions for use by generated code}
 
     You should not need to use these functions directly.

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -112,7 +112,8 @@ module Service_handler : sig
 end
 
 val id : _ t -> int32
-(** [id t] is [t]'s object ID. Use this to refer to the object in a message. *)
+(** [id t] is [t]'s object ID. Use this to refer to the object in a message.
+    @raise Invalid_argument if the proxy has been destroyed (can no longer be used for sending). *)
 
 val id_opt : _ t option -> int32
 (** Like [id] but returns 0l for [None]. *)


### PR DESCRIPTION
This is useful to check whether a proxy has been destroyed.

Also, raise `Invalid_argument` on `Proxy.id` if the proxy is destroyed.