### PR TITLE
Add set_paused to pause processing of incoming messages

### DIFF
--- a/lib/client.ml
+++ b/lib/client.ml
@@ -64,3 +64,5 @@ let sync t =
   result
 
 let wl_display t = t.wl_display
+
+let set_paused t = Connection.set_paused t.conn

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -22,3 +22,7 @@ val sync : t -> unit Lwt.t
 val wl_display : t -> [`V1] Wayland_client.Wl_display.t
 (** [wl_display t] returns the initial object for the display.
     You probably want to use {!Registry.of_display} instead. *)
+
+val set_paused : t -> bool -> unit
+(** [set_paused t] sets the paused state.
+    No further incoming messages will be dispatched while [t] is paused. *)

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -8,3 +8,5 @@ val connect :
   ('role t * ('a, 'v, 'role) Proxy.t)
 
 val closed : [< `Client | `Server ] t -> (unit, exn) Lwt_result.t
+
+val set_paused : _ t -> bool -> unit

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -4,6 +4,8 @@ module Objects = Map.Make(Int32)
 
 type 'role connection = {
   transport : S.transport;
+  mutable paused : unit Lwt.t;                  (* Wait for this to resolve before reading next event. *)
+  mutable unpause : unit -> unit;
   role : 'role;
   mutable objects : 'role generic_proxy Objects.t;
   mutable free_ids : int32 list;


### PR DESCRIPTION
This is useful for https://github.com/talex5/wayland-proxy-virtwl where we sometimes need to do some work on the X11 connection without any Wayland events getting interleaved.