### PR TITLE
Also call on_delete handlers when the connection ends

### DIFF
--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -188,7 +188,8 @@ let delete t =
           send display msg
         )
     end;
-    Queue.iter (fun f -> f ()) t.on_delete
+    Queue.iter (fun f -> f ()) t.on_delete;
+    Queue.clear t.on_delete
   | _ -> Fmt.failwith "Object %a is not registered!" pp t
 
 let delete_other proxy id =
@@ -199,7 +200,8 @@ let delete_other proxy id =
     proxy.can_recv <- false;
     conn.objects <- Objects.remove id conn.objects;
     Internal.free_id conn id;
-    Queue.iter (fun f -> f ()) proxy.on_delete
+    Queue.iter (fun f -> f ()) proxy.on_delete;
+    Queue.clear proxy.on_delete
 
 let unknown_event = Fmt.strf "<unknown event %d>"
 let unknown_request = Fmt.strf "<unknown request %d>"

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -33,7 +33,8 @@ val delete : (_, _, [< `Client | `Server]) t -> unit
 
 val on_delete : (_, _, _) t -> (unit -> unit) -> unit
 (** [on_delete t f] calls [f] when [t] is deleted, either by [delete] being called (on the server)
-    or when the client receives confirmation of the deletion from the server. *)
+    or when the client receives confirmation of the deletion from the server.
+    [f] will also be called if the connection ends. *)
 
 val can_send : (_, _, _) t -> bool
 (** [can_send t] is [true] if the proxy can still be used in out-going messages.


### PR DESCRIPTION
Allows them to be used for cleaning up resources.