### PR TITLE
Improve connection shutdown

### DIFF
--- a/lib/client.mli
+++ b/lib/client.mli
@@ -11,6 +11,7 @@ val connect : ?trace:(module TRACE) ->
     It spawns a background thread to handle incoming messages.
     It returns the new connection and a promise that resolves when
     the connection ends.
+    The caller is responsible for closing [transport] when done.
     @param trace Used to trace all messages sent and received.
                  The default tracer logs messages at debug level, and the log's source is set to debug level
                  if $WAYLAND_DEBUG is "1" or "client" the first time {!connect} is called. *)

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -54,6 +54,8 @@ let metadata t = t.handler#metadata
 
 let can_send t = t.can_send
 
+let transport_up t = t.conn.transport#up
+
 let ty (type a) t =
   let (module M : Metadata.S with type t = a) = metadata t in
   M.T

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -40,6 +40,10 @@ val can_send : (_, _, _) t -> bool
 (** [can_send t] is [true] if the proxy can still be used in out-going messages.
     It becomes false after calling {!delete} or {!shutdown_send}. *)
 
+val transport_up : (_, _, _) t -> bool
+(** [transport_up t] is [true] if [t]'s connection is still active.
+    This is [false] after we read or send end-of-file on the connection. *)
+
 (** {2 Functions for use by generated code}
 
     You should not need to use these functions directly.

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -10,6 +10,14 @@ class type transport = object
       The data is read into [buffer] and the method returns the number of bytes
       read and the list of attached file descriptors. *)
 
+  method shutdown : unit Lwt.t
+  (** Shut down the sending side of the connection. This will cause the peer to read end-of-file. *)
+
+  method up : bool
+  (** [up] is [true] until the transport has sent or received an end-of-file
+      (indicating that the connection is being shut down).
+      This can be accessed via {!Proxy.transport_up}. *)
+
   method pp : Format.formatter -> unit
   (** Can be used for logging. *)
 end

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -3,10 +3,11 @@ type t
 module type TRACE = Proxy.TRACE with type role = [`Server]
 
 val connect : ?trace:(module TRACE) ->
-  S.transport -> ([`Wl_display], [`V1], [`Server]) #Proxy.Service_handler.t -> t
+  #S.transport -> ([`Wl_display], [`V1], [`Server]) #Proxy.Service_handler.t -> t
 (** [connect transport handler] runs the Wayland protocol over [transport]
     (typically created with {!Unix_transport.of_socket}).
     It spawns a background thread to handle incoming messages.
+    The caller is responsible for closing [transport] when done.
     @param trace Used to trace all messages sent and received.
                  The default tracer logs messages at debug level, and the log's source is set to debug level
                  if $WAYLAND_DEBUG is "1" or "server" the first time {!connect} is called. *)

--- a/lib/unix_transport.mli
+++ b/lib/unix_transport.mli
@@ -1,4 +1,10 @@
-val of_socket : Lwt_unix.file_descr -> S.transport
+type t = <
+  S.transport;
+  close : unit Lwt.t;
+  socket : Lwt_unix.file_descr
+>
+
+val of_socket : Lwt_unix.file_descr -> t
 
 val socket_path : ?wayland_display:string -> unit -> string
 (** [socket_path ()] returns the path to the wayland socket to use.
@@ -10,7 +16,7 @@ val socket_path : ?wayland_display:string -> unit -> string
     @param wayland_display Use this as the value of $WAYLAND_DISPLAY
                            instead of reading it from the environment. *)
 
-val connect : unit -> S.transport Lwt.t
+val connect : unit -> t Lwt.t
 (** [connect ()] connects to the Wayland server's socket:
     {ol
     {- If $WAYLAND_SOCKET is set then that file descriptor is used.}


### PR DESCRIPTION
Add `shutdown` and `connected` methods to the transport API. Call `shutdown` to start a clean shutdown of the connection. Use `connected` to detect that a connection is shutting down (to avoid logging pointless errors).

Add `close` and `socket` methods to `unix_transport`.