### PR TITLE
Update to xdg-shell 4

### DIFF
--- a/example/test.ml
+++ b/example/test.ml
@@ -131,6 +131,7 @@ let () =
     in
     let toplevel = Xdg_surface.get_toplevel xdg_surface @@ object
         inherit [_] Xdg_toplevel.v1
+        method on_configure_bounds _ ~width:_ ~height:_ = ()
         method on_configure _ ~width ~height ~states:_ =
           t.width <- if width = 0l then 640 else Int32.to_int width;
           t.height <- if height = 0l then 480 else Int32.to_int height

--- a/protocols/xdg-shell.xml
+++ b/protocols/xdg-shell.xml
@@ -29,7 +29,7 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="xdg_wm_base" version="3">
+  <interface name="xdg_wm_base" version="4">
     <description summary="create desktop-style surfaces">
       The xdg_wm_base interface is exposed as a global object enabling clients
       to turn their wl_surfaces into windows in a desktop environment. It
@@ -75,7 +75,9 @@
       <description summary="create a shell surface from a surface">
 	This creates an xdg_surface for the given surface. While xdg_surface
 	itself is not a role, the corresponding surface may only be assigned
-	a role extending xdg_surface, such as xdg_toplevel or xdg_popup.
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup. It is
+	illegal to create an xdg_surface for a wl_surface which already has an
+	assigned role and this will result in a protocol error.
 
 	This creates an xdg_surface for the given surface. An xdg_surface is
 	used as basis to define a role to a given surface, such as xdg_toplevel
@@ -115,7 +117,7 @@
     </event>
   </interface>
 
-  <interface name="xdg_positioner" version="3">
+  <interface name="xdg_positioner" version="4">
     <description summary="child surface positioner">
       The xdg_positioner provides a collection of rules for the placement of a
       child surface relative to a parent surface. Rules can be defined to ensure
@@ -399,7 +401,7 @@
     </request>
   </interface>
 
-  <interface name="xdg_surface" version="3">
+  <interface name="xdg_surface" version="4">
     <description summary="desktop user interface surface base interface">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
@@ -444,7 +446,8 @@
 
       A newly-unmapped surface is considered to have met condition (1) out
       of the 3 required conditions for mapping a surface if its role surface
-      has not been destroyed.
+      has not been destroyed, i.e. the client must perform the initial commit
+      again before attaching a buffer.
     </description>
 
     <enum name="error">
@@ -574,7 +577,7 @@
 
   </interface>
 
-  <interface name="xdg_toplevel" version="3">
+  <interface name="xdg_toplevel" version="4">
     <description summary="toplevel surface">
       This interface defines an xdg_surface role which allows a surface to,
       among other things, set window-like properties such as maximize,
@@ -601,6 +604,11 @@
 	see "Unmapping" behavior in interface section for details.
       </description>
     </request>
+
+    <enum name="error">
+      <entry name="invalid_resize_edge" value="0" summary="provided value is
+        not a valid variant of the resize_edge enum"/>
+    </enum>
 
     <request name="set_parent">
       <description summary="set the parent of this surface">
@@ -751,12 +759,13 @@
 	guarantee that the device focus will return when the resize is
 	completed.
 
-	The edges parameter specifies how the surface should be resized,
-	and is one of the values of the resize_edge enum. The compositor
-	may use this information to update the surface position for
-	example when dragging the top left corner. The compositor may also
-	use this information to adapt its behavior, e.g. choose an
-	appropriate cursor image.
+	The edges parameter specifies how the surface should be resized, and
+	is one of the values of the resize_edge enum. Values not matching
+	a variant of the enum will cause a protocol error. The compositor
+	may use this information to update the surface position for example
+	when dragging the top left corner. The compositor may also use
+	this information to adapt its behavior, e.g. choose an appropriate
+	cursor image.
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
       <arg name="serial" type="uint" summary="the serial of the user event"/>
@@ -807,25 +816,25 @@
 	</description>
       </entry>
       <entry name="tiled_left" value="5" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s left edge is tiled">
 	  The window is currently in a tiled layout and the left edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_right" value="6" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s right edge is tiled">
 	  The window is currently in a tiled layout and the right edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_top" value="7" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s top edge is tiled">
 	  The window is currently in a tiled layout and the top edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
       </entry>
       <entry name="tiled_bottom" value="8" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s bottom edge is tiled">
 	  The window is currently in a tiled layout and the bottom edge is
 	  considered to be adjacent to another part of the tiling grid.
 	</description>
@@ -1067,9 +1076,33 @@
 	a dialog to ask the user to save their data, etc.
       </description>
     </event>
+
+    <!-- Version 4 additions -->
+
+    <event name="configure_bounds" since="4">
+      <description summary="recommended window geometry bounds">
+	The configure_bounds event may be sent prior to a xdg_toplevel.configure
+	event to communicate the bounds a window geometry size is recommended
+	to constrain to.
+
+	The passed width and height are in surface coordinate space. If width
+	and height are 0, it means bounds is unknown and equivalent to as if no
+	configure_bounds event was ever sent for this surface.
+
+	The bounds can for example correspond to the size of a monitor excluding
+	any panels or other shell components, so that a surface isn't created in
+	a way that it cannot fit.
+
+	The bounds may change at any point, and in such a case, a new
+	xdg_toplevel.configure_bounds will be sent, followed by
+	xdg_toplevel.configure and xdg_surface.configure.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
   </interface>
 
-  <interface name="xdg_popup" version="3">
+  <interface name="xdg_popup" version="4">
     <description summary="short-lived, popup surfaces for menus">
       A popup surface is a short-lived, temporary surface. It can be used to
       implement for example menus, popovers, tooltips and other similar user


### PR DESCRIPTION
The example doesn't build when using latest xdg-shell 4, because the `on_configure_bounds` virtual method was added.