### PR TITLE
Cope with interfaces that are always v1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Update protocols to latest versions (@talex5 #43).
 
+- Cope with interfaces that are always v1 (@talex5 #44).
+
 # v2.0
 
 - Convert from Lwt to Eio (@talex5 #37).  


### PR DESCRIPTION
Normally the child has the same version as the parent. But some interfaces don't follow this rule (wl_callback, wl_buffer, wl_region) and remain at v1 always. Special-case that.