### PR TITLE
Support posting protocol errors

### DIFF
--- a/lib/client.mli
+++ b/lib/client.mli
@@ -4,7 +4,7 @@ type t
 
 module type TRACE = Proxy.TRACE with type role = [`Client]
 
-type error_callback = object_id:int32 -> code:int32 -> message:string -> unit
+type error_callback = id:int32 -> code:int32 -> message:string -> unit
 (** [error_callback] is the type of callbacks to be invoked when a
     fatal protocol error occurs. *)
 

--- a/lib/client.mli
+++ b/lib/client.mli
@@ -4,7 +4,11 @@ type t
 
 module type TRACE = Proxy.TRACE with type role = [`Client]
 
-val connect : ?trace:(module TRACE) -> sw:Eio.Switch.t -> #S.transport -> t
+type error_callback = object_id:int32 -> code:int32 -> message:string -> unit
+(** [error_callback] is the type of callbacks to be invoked when a
+    fatal protocol error occurs. *)
+
+val connect : ?trace:(module TRACE) -> sw:Eio.Switch.t -> ?error_callback:error_callback -> #S.transport -> t
 (** [connect ~sw transport] runs the Wayland protocol over [transport]
     (typically created with {!Unix_transport.connect}).
 
@@ -12,11 +16,14 @@ val connect : ?trace:(module TRACE) -> sw:Eio.Switch.t -> #S.transport -> t
     If the thread gets an error then the switch will be cancelled.
 
     The caller is responsible for ensuring [transport] is closed,
-    but the library will shut it down if it gets end-of-file from the server.
+    but the library will shut it down if it gets end-of-file or a protocol
+    error from the server.
 
     @param trace Used to trace all messages sent and received.
                  The default tracer logs messages at debug level, and the log's source is set to debug level
-                 if $WAYLAND_DEBUG is "1" or "client" the first time {!connect} is called. *)
+                 if $WAYLAND_DEBUG is "1" or "client" the first time {!connect} is called.
+    @param error_callback Callback called if a protocol error happens.
+                          The default callback logs a message at error level. *)
 
 val sync : t -> unit
 (** Send a sync message to the server and wait for the reply.

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -41,6 +41,8 @@ let rec process_recv_buffer t recv_buffer =
               true
             with
             | Proxy.Error { id; code; message } when is_server ->
+               Log.warn (fun f -> f "Protocol error handling incoming message for %a: code %d, message %s"
+                         pp_proxy proxy (Int32.to_int code) message);
                post_error t ~id ~code ~message;
                false
             | ex ->

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -2,18 +2,6 @@ open Eio.Std
 open Internal
 
 type 'a t = 'a Internal.connection
-let post_error t ~(id: int32) ~(code: int32) ~(message: string) =
-  match t.role with
-  | `Client -> ()
-  | `Server -> (
-    let _msg = Msg.alloc ~obj:1l ~op:0 ~ints:3 ~strings:[(Some message)] ~arrays:[] in
-    Msg.add_int _msg id;
-    Msg.add_int _msg code;
-    Msg.add_string _msg message;
-    match t.display_proxy with
-    | None -> assert false
-    | Some proxy -> Proxy.send proxy _msg
-  )
 
 (** Dispatch all complete messages in [recv_buffer].
     Return [true] if everything was okay and [false] to shut down the connection. *)
@@ -30,7 +18,7 @@ let rec process_recv_buffer t recv_buffer =
        match Objects.find_opt obj t.objects with
        | None ->
           let message = Format.asprintf "No such object %lu (op=%d)" obj (Msg.op msg) in
-          (if is_server then post_error t ~id:1l (* wl_display *) ~code:0l (* invalid_object *) ~message);
+          (if is_server then Internal.error t ~id:1l (* wl_display *) ~code:0l (* invalid_object *) ~message);
           false
        | Some (Generic proxy) ->
           let msg = Msg.cast msg in
@@ -43,7 +31,7 @@ let rec process_recv_buffer t recv_buffer =
             | Proxy.Error { id; code; message } when is_server ->
                Log.warn (fun f -> f "Protocol error handling incoming message for %a: code %d, message %s"
                          pp_proxy proxy (Int32.to_int code) message);
-               post_error t ~id ~code ~message;
+               Internal.error t ~id ~code ~message;
                false
             | ex ->
                let bt = Printexc.get_raw_backtrace () in
@@ -52,9 +40,9 @@ let rec process_recv_buffer t recv_buffer =
                if is_server then (
                  match ex with
                  | Out_of_memory | Stack_overflow ->
-                    post_error t ~id:0l ~code:2l ~message:"Out of memory";
+                    Internal.error t ~id:1l ~code:2l ~message:"Out of memory";
                     raise ex (* System is now in undefined state, exit! *)
-                 | _ -> post_error t ~id:0l ~code:3l ~message:"Uncaught OCaml exception"
+                 | _ -> Internal.error t ~id:1l ~code:3l ~message:"Uncaught OCaml exception"
                );
                false
           ) else (
@@ -69,6 +57,8 @@ let rec process_recv_buffer t recv_buffer =
      else
        false
 
+let stop = Internal.shutdown
+
 let listen t =
   Switch.run @@ fun sw ->
   let recv_buffer = Recv_buffer.create 4096 in
@@ -77,7 +67,7 @@ let listen t =
     List.iter (fun fd -> Queue.add (Eio_unix.Fd.remove fd |> Option.get) t.incoming_fds) fds;
     if got = 0 then (
       Log.info (fun f -> f "Got end-of-file on wayland connection");
-      t.transport#shutdown
+      stop t
     ) else (
       Recv_buffer.update_producer recv_buffer got;
       Log.debug (fun f -> f "Ring after adding %d bytes: %a" got Recv_buffer.dump recv_buffer);
@@ -85,7 +75,7 @@ let listen t =
         aux ()
       else (
         Log.err (fun f -> f "Connection closed unexpectedly");
-        t.transport#shutdown
+        stop t
       )
     )
   in
@@ -108,6 +98,7 @@ let clean_up t =
 let connect ~sw ~trace role transport handler =
   let incoming_fds = Queue.create () in
   Switch.on_release sw (fun () -> Queue.iter Unix.close incoming_fds);
+  let (promise, resolver) = Eio.Promise.create () in
   let t = {
     sw;
     transport = (transport :> S.transport);
@@ -120,6 +111,9 @@ let connect ~sw ~trace role transport handler =
     outbox = Queue.create ();
     trace = Proxy.trace trace;
     display_proxy = None;
+    error = No_error;
+    promise;
+    resolver;
   } in
   let display_proxy = Proxy.add_root t (handler :> _ Proxy.Handler.t) in
   t.display_proxy <- Some display_proxy;
@@ -129,8 +123,7 @@ let connect ~sw ~trace role transport handler =
     );
   (t, display_proxy)
 
-let stop t =
-  t.transport#shutdown
+let error (t: [`Server] t) = Internal.error t
 
 let dump f t =
   let pp_item f (_id, Generic proxy) = pp_proxy f proxy in

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -77,6 +77,7 @@ let connect ~sw ~trace role transport handler =
     incoming_fds;
     outbox = Queue.create ();
     trace = Proxy.trace trace;
+    display_proxy = None;
   } in
   let display_proxy = Proxy.add_root t (handler :> _ Proxy.Handler.t) in
   Eio.Fiber.fork ~sw (fun () ->

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -80,6 +80,7 @@ let connect ~sw ~trace role transport handler =
     display_proxy = None;
   } in
   let display_proxy = Proxy.add_root t (handler :> _ Proxy.Handler.t) in
+  t.display_proxy <- Some display_proxy;
   Eio.Fiber.fork ~sw (fun () ->
       Fun.protect (fun () -> listen t)
         ~finally:(fun () -> clean_up t)

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -11,3 +11,5 @@ val connect :
 val stop : [< `Client | `Server ] t -> unit
 
 val dump : _ t Fmt.t
+
+val error : [ `Server ] t -> id:int32 -> code:int32 -> message:string -> unit

--- a/lib/connection.mli
+++ b/lib/connection.mli
@@ -5,8 +5,8 @@ val connect :
   trace:(module Proxy.TRACE with type role = 'role) ->
   ([< `Client | `Server] as 'role) ->
   #S.transport ->
-  ('a, 'v, 'role) #Proxy.Service_handler.t ->
-  ('role t * ('a, 'v, 'role) Proxy.t)
+  ([`Wl_display], 'v, 'role) #Proxy.Service_handler.t ->
+  ('role t * ([`Wl_display], 'v, 'role) Proxy.t)
 
 val stop : [< `Client | `Server ] t -> unit
 

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -13,6 +13,7 @@ type 'role connection = {
   incoming_fds : Unix.file_descr Queue.t;
   outbox : (unit, [`W]) Msg.t Queue.t;          (* The transmit thread is running whenever this is non-empty. *)
   trace : 'role tracer;
+  mutable display_proxy : ([`Wl_display], [`V1], 'role) versioned_proxy option;
 } and ('a, 'role) proxy = {
   id : int32;
   conn : 'role connection;

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -31,7 +31,7 @@ and ('a, 'role) handler = <
 and 'role tracer = {
   outbound : 'a. ('a, 'role) proxy -> ('a, [`W]) Msg.t -> unit;
   inbound : 'a. ('a, 'role) proxy -> ('a, [`R]) Msg.t -> unit;
-}
+} and ('a, +'v, 'role) versioned_proxy = ('a, 'role) proxy
 
 let get_unused_id t =
   match t.free_ids with

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -6,6 +6,12 @@ type 'a role =
   | Server : [`Server] role
   | Client : [`Client] role
 
+type +'a error =
+  | Error : { id: int32; code: int32; message: string } -> 'a error
+  | No_error : 'a error
+  | Shutdown : 'a error
+  | Done : 'a error
+
 type 'role connection = {
   sw : Switch.t;
   transport : S.transport;
@@ -18,6 +24,9 @@ type 'role connection = {
   outbox : (unit, [`W]) Msg.t Queue.t;          (* The transmit thread is running whenever this is non-empty. *)
   trace : 'role tracer;
   mutable display_proxy : ([`Wl_display], [`V1], 'role) versioned_proxy option;
+  mutable error : 'role error;
+  promise : unit Eio.Promise.t;
+  resolver : unit Eio.Promise.u;
 } and ('a, 'role) proxy = {
   id : int32;
   conn : 'role connection;
@@ -63,9 +72,31 @@ let free_id t id =
   if id_allocated_by_us t id then
     t.free_ids <- id :: t.free_ids
 
+let check_error t =
+  match t.error with
+  | No_error -> ()
+  | Error { id; code;  message } ->
+    t.error <- Done;
+    let _msg: ([`Wl_display], [`W]) Msg.t = Msg.alloc ~obj:1l ~op:0 ~ints:3 ~strings:[(Some message)] ~arrays:[] in
+    Msg.add_int _msg id;
+    Msg.add_int _msg code;
+    Msg.add_string _msg message;
+    begin match t.display_proxy with
+    | None -> ()
+    | Some proxy -> t.trace.outbound proxy _msg
+    end;
+    t.transport#send (Cstruct.of_bigarray (Msg.buffer _msg)) [];
+    t.transport#shutdown;
+    Eio.Promise.resolve t.resolver ()
+  | Shutdown ->
+    t.error <- Done;
+    t.transport#shutdown;
+    Eio.Promise.resolve t.resolver ()
+  | Done -> ()
+
 (* Call this when adding an item to an empty [outbox].
    On exit, the outbox is empty again. *)
-let rec transmit t =
+let rec transmit: [<`Client|`Server] connection -> unit = fun t ->
   let msg = Queue.peek t.outbox in  (* Just peek, to show that we're still running *)
   let buffer = Msg.buffer msg in
   (* todo: could do several messages at once *)
@@ -76,26 +107,54 @@ let rec transmit t =
       Queue.clear unix_fds;
       t.transport#send (Cstruct.of_bigarray buffer) fds
     );
-  ignore (Queue.pop t.outbox);
-  if not (Queue.is_empty t.outbox) then
+  if Queue.length t.outbox > 1 then (
+    ignore (Queue.pop t.outbox);
     transmit t
+  ) else (
+    (* Transmit the error *then* pop the queue, so that we cannot yield
+       while the queue is empty *)
+    check_error t;
+    ignore (Queue.pop t.outbox)
+  )
 
 let cancel_msg (m : (_, [`W]) Msg.t) =
   Queue.iter Unix.close (Msg.fds m)
 
-let enqueue t msg =
-  let start_transmit_thread = Queue.is_empty t.outbox in
-  Queue.add msg t.outbox;
-  if start_transmit_thread then (
-    Fiber.fork ~sw:t.sw
-      (fun () ->
-         try
-           Fun.protect (fun () -> transmit t)
-             ~finally:(fun () -> Queue.iter cancel_msg t.outbox; Queue.clear t.outbox)
-         with Eio.Io _ as ex when not t.transport#up ->
-           Log.debug (fun f -> f "Transmit failed (but connection already shut down): %a" Fmt.exn ex);
-      )
-  )
+let error (t: [<`Client|`Server] connection) ~id ~code ~message =
+  match t.error with
+  | No_error ->
+    t.error <- Error { id; code; message };
+    if Queue.is_empty t.outbox then
+      Fiber.fork ~sw:t.sw
+        (fun () ->
+          try
+            check_error t
+          with Eio.Io _ as ex when not t.transport#up ->
+            Log.debug (fun f -> f "Transmit failed (but connection already shut down): %a" Fmt.exn ex))
+  | Error _ | Shutdown | Done -> ()
+
+let shutdown (t: [<`Client|`Server] connection) =
+  match t.error with
+  | No_error ->
+    t.error <- Shutdown;
+    begin match Queue.length t.outbox with
+    | 0 -> check_error t
+    | _ -> Eio.Promise.await t.promise
+    end
+  | Error _ | Shutdown | Done -> Eio.Promise.await t.promise
+
+let enqueue (t: 'a connection) msg =
+  if t.error = No_error then
+    let start_transmit_thread = Queue.is_empty t.outbox in
+    Queue.add msg t.outbox;
+    if start_transmit_thread then
+      Fiber.fork ~sw:t.sw
+        (fun () ->
+          try
+            Fun.protect (fun () -> transmit t)
+              ~finally:(fun () -> Queue.iter cancel_msg t.outbox; Queue.clear t.outbox)
+          with Eio.Io _ as ex when not t.transport#up ->
+            Log.debug (fun f -> f "Transmit failed (but connection already shut down): %a" Fmt.exn ex))
 
 let pp_proxy f (type a) (x: (a, _) proxy) =
   let (module M : Metadata.S with type t = a) = x.handler#metadata in

--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -2,6 +2,10 @@ open Eio.Std
 
 module Objects = Map.Make(Int32)
 
+type 'a role =
+  | Server : [`Server] role
+  | Client : [`Client] role
+
 type 'role connection = {
   sw : Switch.t;
   transport : S.transport;

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -116,6 +116,11 @@ let id t =
   if t.can_send then t.id
   else Fmt.invalid_arg "Attempt to use %a after destroying it" pp t
 
+exception Error of { id: int32; code: int32; message: string }
+
+let post_error t ~code ~message =
+  raise (Error { id = id t; code = code; message = message })
+
 let id_opt = function
   | None -> 0l
   | Some t -> id t

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -127,7 +127,7 @@ let id_opt = function
 
 let alloc t = Msg.alloc ~obj:t.id
 
-let send (type a) (t:_ t) (msg : (a, [`W]) Msg.t) =
+let send (type a) (t: (_, _, [<`Client|`Server]) t) (msg : (a, [`W]) Msg.t) =
   t.conn.trace.outbound t msg;
   if t.can_send then
     enqueue t.conn (Msg.cast msg)
@@ -177,7 +177,7 @@ let add_root conn (handler : (_, _, _) #Handler.t) =
 let on_delete t fn =
   Queue.add fn t.on_delete
 
-let delete t =
+let delete (t: ('a, [< `Client | `Server]) Internal.proxy): unit =
   let conn = t.conn in
   match Objects.find_opt t.id conn.objects with
   | Some (Generic t') when Obj.repr t == Obj.repr t' ->

--- a/lib/proxy.ml
+++ b/lib/proxy.ml
@@ -1,6 +1,6 @@
 open Internal
 
-type ('a, 'v, 'role) t = ('a, 'role) Internal.proxy
+type ('a, 'v, 'role) t = ('a, 'v, 'role) versioned_proxy
 
 type ('a, 'v, 'role) proxy = ('a, 'v, 'role) t
 

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -216,3 +216,15 @@ val wrong_type : parent:_ t -> expected:string -> _ t -> 'a
 (** [wrong_type ~parent ~expected t] fails with an exception complaining that [t] should have type [expected]. *)
 
 val trace : (module TRACE with type role = 'role) -> 'role Internal.tracer
+
+val post_error : ('a, [>`V1], [<`Server]) t -> code:int32 -> message:string -> 'b
+(** [post_error t ~code ~message] raises a protocol error with code [code] and message [message].
+    It does not return. *)
+
+exception Error of { id: int32; code: int32; message: string }
+(** Fatal error event.
+
+    Raised by servers to indicate a protocol error.
+
+    Clients should not raise this exception.  If they do, it will be treated as any other
+    uncaught exception. *)

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -221,7 +221,7 @@ val post_error : ('a, [>`V1], [<`Server]) t -> code:int32 -> message:string -> '
 (** [post_error t ~code ~message] raises a protocol error with code [code] and message [message].
     It does not return. *)
 
-exception Error of { id: int32; code: int32; message: string }
+exception Error of { object_id: int32; code: int32; message: string }
 (** Fatal error event.
 
     Raised by servers to indicate a protocol error.

--- a/lib/proxy.mli
+++ b/lib/proxy.mli
@@ -1,6 +1,6 @@
 (** {2 Types} *)
 
-type ('a, +'v, 'role) t
+type ('a, +'v, 'role) t = ('a, 'v, 'role) Internal.versioned_proxy
 (** An [('a, 'v, 'role) t] is a proxy used by ['role] to send messages to an object with interface ['a] and version in ['v]. *)
 
 val user_data : ('a, _, 'role) t -> ('a, 'role) S.user_data

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -48,5 +48,11 @@ let connect ?(trace=(module Trace : TRACE)) ~sw transport handler =
 
 let wl_display t = t.wl_display
 
+let implementation_error t message =
+  Connection.error t.conn ~object_id:1l ~code:3l ~message
+
+let no_memory t message =
+  Connection.error t.conn ~object_id:1l ~code:2l ~message
+
 let dump f t = Connection.dump f t.conn
 let stop t = Connection.stop t.conn

--- a/lib/server.mli
+++ b/lib/server.mli
@@ -24,3 +24,9 @@ val stop : t -> unit
 
 val dump : t Fmt.t
 (** Dump the state of the connection for debugging. *)
+
+val implementation_error : t -> string -> unit
+(** Disconnect the client with a message indicating a compositor bug. *)
+
+val no_memory : t -> string -> unit
+(** Disconnect the client with a message indicating that the server ran out of memory. *)


### PR DESCRIPTION
This allows posting protocol errors to a client.  This is a prerequisite for proper validation of inputs by servers and clients.