### PR TITLE
Replace "@<id>" with "#<id>" in logs

### DIFF
--- a/lib/internal.ml
+++ b/lib/internal.ml
@@ -94,4 +94,4 @@ let enqueue t msg =
 
 let pp_proxy f (type a) (x: (a, _) proxy) =
   let (module M : Metadata.S with type t = a) = x.handler#metadata in
-  Fmt.pf f "%s@%lu" M.interface x.id
+  Fmt.pf f "%s#%lu" M.interface x.id


### PR DESCRIPTION
We previously used `@` to match the C libwayland, but that has now switched to `#` (to avoid confusion with email addresses when anonymizing logs from users).