### PR TITLE
fix: mangle `new`

### DIFF
--- a/scanner/generate.ml
+++ b/scanner/generate.ml
@@ -22,7 +22,8 @@ let mangle name =
   | "method"
   | "handlers"
   | "h"
-  | "done" -> name ^ "_"
+  | "done"
+  | "new" -> name ^ "_"
   | x -> x
 
 let pp_role f = function


### PR DESCRIPTION
Got a syntax error from [this](https://codeberg.org/river/river/src/branch/main/protocol/river-xkb-bindings-v1.xml) protocol I'm using

```xml
      <arg name="new" type="uint" enum="river_seat_v1.modifiers"
        summary="currently active modifiers"/>
```